### PR TITLE
Fix build with qt 5.11

### DIFF
--- a/src/convertDlg.cpp
+++ b/src/convertDlg.cpp
@@ -25,6 +25,7 @@
 #include <QFileDialog>
 #include <QMimeType>
 #include <QMimeDatabase>
+#include <QStyle>
 //ImageMagick
 #include <Magick++.h>
 

--- a/src/userDlg.cpp
+++ b/src/userDlg.cpp
@@ -22,6 +22,8 @@
 #include <KMessageBox>
 //Qt
 #include <QPushButton>
+#include <QStyle>
+#include <QRegExpValidator>
 //Ui
 #include "ui_userDlg.h"
 


### PR DESCRIPTION
Fix build with qt 5.11
Based on patch from https://github.com/OpenMandrivaAssociation/grub2-editor/blob/master/grub2-editor-0.7.1-qt-5.11.patch

Original author @berolinux